### PR TITLE
fix(interpreter): coerce boolean values to 0/1 in numeric columns

### DIFF
--- a/crates/interpreter/src/converters.rs
+++ b/crates/interpreter/src/converters.rs
@@ -133,6 +133,7 @@ pub fn sheet_to_arrow(sheet: &Sheet, skip_first_row: usize) -> PipResult<RecordB
                             match cell {
                                 CellValue::Float(f) => values.push(Some(*f)),
                                 CellValue::Int(i) => values.push(Some(*i as f64)),
+                                CellValue::Bool(b) => values.push(Some(if *b { 1.0 } else { 0.0 })),
                                 _ => values.push(None),
                             }
                         } else {
@@ -151,6 +152,7 @@ pub fn sheet_to_arrow(sheet: &Sheet, skip_first_row: usize) -> PipResult<RecordB
                         if let Some(cell) = row.get(col_idx) {
                             match cell {
                                 CellValue::Int(i) => values.push(Some(*i)),
+                                CellValue::Bool(b) => values.push(Some(if *b { 1 } else { 0 })),
                                 _ => values.push(None),
                             }
                         } else {


### PR DESCRIPTION
## Summary
Fix data loss issue where boolean values were silently dropped (converted to None/null) when appearing in columns classified as numeric (Int64 or Float64).

## Changes
- Coerce boolean values to numeric values in sheet_to_arrow conversion:
  - true -> 1 (or 1.0 for float columns)
  - false -> 0 (or 0.0 for float columns)
- Matches standard SQL behavior and prevents silent data loss

## Test plan
- [x] All existing tests pass
- [x] No new test failures introduced
- [x] Verified bool coercion works correctly in mixed-type columns

Fixes part of #148 (CodeRabbit finding from PR #147)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of boolean values in numeric data columns. Boolean values are now properly converted to numeric representations (0 or 1) when mixed with numeric data types, resulting in more accurate column type inference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->