### PR TITLE
refactor: remove pdf-extract dependency and consolidate on lopdf (#92)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "adobe-cmap-parser"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
-dependencies = [
- "pom",
-]
-
-[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,12 +822,6 @@ checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.3",
 ]
-
-[[package]]
-name = "cff-parser"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f5b6e9141c036f3ff4ce7b2f7e432b0f00dee416ddcd4f17741d189ddc2e9d"
 
 [[package]]
 name = "cfg-if"
@@ -1728,15 +1713,6 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
-name = "euclid"
-version = "0.20.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "exr"
@@ -2725,34 +2701,6 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
-dependencies = [
- "aes",
- "bitflags 2.10.0",
- "cbc",
- "ecb",
- "encoding_rs",
- "flate2",
- "getrandom 0.3.4",
- "indexmap",
- "itoa",
- "log",
- "md-5",
- "nom 8.0.0",
- "nom_locate",
- "rand 0.9.2",
- "rangemap",
- "sha2",
- "stringprep",
- "thiserror 2.0.18",
- "ttf-parser",
- "weezl",
-]
-
-[[package]]
-name = "lopdf"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f560f57dfb9142a02d673e137622fd515d4231e51feb8b4af28d92647d83f35b"
@@ -3265,23 +3213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
-name = "pdf-extract"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28ba1758a3d3f361459645780e09570b573fc3c82637449e9963174c813a98"
-dependencies = [
- "adobe-cmap-parser",
- "cff-parser",
- "encoding_rs",
- "euclid",
- "log",
- "lopdf 0.38.0",
- "postscript",
- "type1-encoding-parser",
- "unicode-normalization",
-]
-
-[[package]]
 name = "pdfium-render"
 version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,8 +3426,7 @@ dependencies = [
  "anyhow",
  "image",
  "lazy_static",
- "lopdf 0.39.0",
- "pdf-extract",
+ "lopdf",
  "pdfium-render",
  "piptable-sheet",
  "regex",
@@ -3608,12 +3538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pom"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3627,12 +3551,6 @@ checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
-
-[[package]]
-name = "postscript"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
@@ -4961,15 +4879,6 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
-name = "type1-encoding-parser"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d6cc09e1a99c7e01f2afe4953789311a1c50baebbdac5b477ecf78e2e92a5b"
-dependencies = [
- "pom",
-]
 
 [[package]]
 name = "typenum"

--- a/crates/pdf/Cargo.toml
+++ b/crates/pdf/Cargo.toml
@@ -13,7 +13,6 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 
 # PDF processing
-pdf-extract = "0.10"
 lopdf = "0.39"
 
 # OCR support (Phase 1B)

--- a/crates/pdf/src/extractor.rs
+++ b/crates/pdf/src/extractor.rs
@@ -2,7 +2,6 @@ use crate::detector::{TableDetector, TableRegion};
 use crate::error::{PdfError, Result};
 use crate::ocr::OcrEngine;
 use lopdf::Document;
-use pdf_extract::extract_text;
 use pdfium_render::prelude::*;
 use std::path::Path;
 
@@ -150,20 +149,8 @@ impl PdfExtractor {
     }
 
     fn extract_text_from_pdf(&self, path: &Path) -> Result<String> {
-        // Use lopdf when a page range is requested, so the range is honored
-        if self.options.page_range.is_some() {
-            return self.extract_text_with_lopdf(path);
-        }
-
-        // Use pdf-extract for full-document extraction
-        match extract_text(path) {
-            Ok(text) => Ok(text),
-            Err(e) => {
-                // Try alternative method with lopdf
-                tracing::warn!("pdf-extract failed, trying lopdf: {}", e);
-                self.extract_text_with_lopdf(path)
-            }
-        }
+        // Always use lopdf for consistent text extraction
+        self.extract_text_with_lopdf(path)
     }
 
     fn extract_text_with_lopdf(&self, path: &Path) -> Result<String> {


### PR DESCRIPTION
## Summary

Removes the `pdf-extract` dependency and consolidates all PDF text extraction on `lopdf` v0.39, simplifying our PDF processing stack.

## Motivation

We were using both `pdf-extract` and `lopdf` which caused:
- Duplicate dependencies (`lopdf` v0.38 via `pdf-extract` + v0.39 directly)
- Inconsistent APIs between libraries
- Larger binary size
- Unnecessary complexity with fallback logic

## Changes

### 🗑️ **Removed**
- `pdf-extract` dependency completely removed
- Fallback logic between two libraries

### ✅ **Simplified**
- All PDF text extraction now uses `lopdf` exclusively
- Single consistent API throughout the codebase
- Cleaner, more maintainable code

### 📊 **Results**
- **Before**: 2 PDF libraries, 2 versions of lopdf
- **After**: 1 PDF library (lopdf v0.39 only)
- **Binary size**: Reduced due to fewer dependencies
- **Code complexity**: Significantly simplified

## Testing

- [x] All existing tests pass
- [x] PDF text extraction verified working
- [x] OCR functionality unaffected
- [x] CLI builds successfully

## Impact

No breaking changes - this is an internal refactor that maintains the same external API.

Closes #92 (partial - removes one source of inconsistency)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified PDF text extraction by consolidating to a single, optimized extraction method, reducing complexity while maintaining functionality.

* **Chores**
  * Removed unused dependency from project configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->