### PR TITLE
docs: add TODO comment for scraper crate update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ csv = "1.3"
 parquet = "53"
 
 # HTML parsing
-scraper = "0.22"
+scraper = "0.22" # TODO: Update to 0.25 - currently blocked by Python linking issues
 
 # Testing
 wiremock = "0.6"


### PR DESCRIPTION
## Summary
- Add TODO comment documenting the need to update scraper from 0.22 to 0.25
- Update is currently blocked by Python linking issues

## Details
The scraper crate can be updated from 0.22 to 0.25, but this triggers Python linking failures that appear unrelated to the scraper update itself. The TODO comment documents this for future investigation.

## Related
- Addresses CodeRabbit feedback about updating scraper version
- Python linking issues need separate investigation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
* Updated internal dependency documentation with a note for future maintenance considerations.

---

*This release contains only internal updates with no user-facing changes.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->